### PR TITLE
Reset issue while adding new datetime field in a form. #27

### DIFF
--- a/autoform-bs-datetimepicker.js
+++ b/autoform-bs-datetimepicker.js
@@ -100,8 +100,6 @@ Template.afBootstrapDateTimePicker.rendered = function () {
     // set field value
     if (data.value instanceof Date) {
       dtp.setDate(data.value);
-    } else {
-      dtp.setDate(); // clear
     }
 
     // set start date if there's a min in the schema


### PR DESCRIPTION
Below is my Schema

```
  Players = new Meteor.Collection('players');
  MatchSchema = new SimpleSchema({
    title: {
      max: 50,
      type: String
    },
    start: {
      type: Date,
      autoform: {
        afFieldInput: {
          type: "bootstrap-datetimepicker"
        }
      },
      label: "Start date"
    }
  });

  PlayerSchema = new SimpleSchema({
    name: {
      max: 50,
      type: String
    },
    match: {
      type: [MatchSchema],
      min: 1
    }
  });

  Players.attachSchema(PlayerSchema);
```

I have created example app [here](http://datepickerissue.meteor.com/). When user try to add a new date the previous selected date is getting reset.
