### PR TITLE
Upgrade to sega:bootstrap3-datetimepicker@4.17.37_1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ In a Meteor app directory, enter:
 
 ```bash
 $ meteor add twbs:bootstrap
-$ meteor add tsega:bootstrap3-datetimepicker@=3.1.3_3
 $ meteor add aldeed:autoform
 ```
 

--- a/autoform-bs-datetimepicker.js
+++ b/autoform-bs-datetimepicker.js
@@ -16,12 +16,12 @@ AutoForm.addInputType("bootstrap-datetimepicker", {
     return val;
   },
   valueOut: function () {
-    var m = this.data("DateTimePicker").getDate();
-    
+    var m = this.data("DateTimePicker").date();
+
     if (!m) {
       return m;
     }
-    
+
     var timezoneId = this.attr("data-timezone-id");
     // default is local, but if there's a timezoneId, we use that
     if (typeof timezoneId === "string") {
@@ -81,7 +81,7 @@ Template.afBootstrapDateTimePicker.rendered = function () {
   var $input = this.$('input');
   var data = this.data;
   var opts = data.atts.dateTimePickerOptions || {};
-  
+
   // To be able to properly detect a cleared field, the defaultDate,
   // which is "" by default, must be null instead. Otherwise we get
   // the current datetime when we call getDate() on an empty field.
@@ -99,19 +99,19 @@ Template.afBootstrapDateTimePicker.rendered = function () {
 
     // set field value
     if (data.value instanceof Date) {
-      dtp.setDate(data.value);
+      dtp.date(data.value);
     } else {
-      dtp.setDate(); // clear
+      dtp.date(null); // clear
     }
 
     // set start date if there's a min in the schema
     if (data.min instanceof Date) {
-      dtp.setMinDate(data.min);
+      dtp.minDate(data.min);
     }
 
     // set end date if there's a max in the schema
     if (data.max instanceof Date) {
-      dtp.setMaxDate(data.max);
+      dtp.maxDate(data.max);
     }
   });
 

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'aldeed:autoform-bs-datetimepicker',
   summary: 'Custom bootstrap-datetimepicker input type with timezone support for AutoForm',
-  version: '1.0.6',
+  version: '1.0.7',
   git: 'https://github.com/aldeed/meteor-autoform-bs-datetimepicker.git'
 });
 
@@ -9,6 +9,7 @@ Package.onUse(function(api) {
   api.use('templating@1.0.0');
   api.use('blaze@2.0.0');
   api.use('aldeed:autoform@4.0.0 || 5.0.0');
+  api.use('tsega:bootstrap3-datetimepicker@4.17.37_1');
 
   // Ensure momentjs packages load before this one if used
   api.use('momentjs:moment@2.8.4', 'client', {weak: true});


### PR DESCRIPTION
Upgrade to sega:bootstrap3-datetimepicker@4.17.37_1

Also added direct dependancy within the package so users don't need to install seperately.

Fixes #20, #26, #23, #24, #22, #12
